### PR TITLE
add 'ignore' case to create_layered_volume 

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Run tox
       run: |
-        tox -etests
+        tox
 
   lint:
     runs-on: ubuntu-latest

--- a/atlas_commons/utils.py
+++ b/atlas_commons/utils.py
@@ -5,6 +5,7 @@ from typing import Dict, Tuple
 
 import numpy as np
 import voxcell
+import re
 
 from atlas_commons.exceptions import AtlasCommonsError
 from atlas_commons.typing import AnnotationT, BoolArray, FloatArray, NumericArray

--- a/atlas_commons/utils.py
+++ b/atlas_commons/utils.py
@@ -1,11 +1,11 @@
 """Generic atlas tools"""
 from __future__ import annotations
 
+import re
 from typing import Dict, Tuple
 
 import numpy as np
 import voxcell
-import re
 
 from atlas_commons.exceptions import AtlasCommonsError
 from atlas_commons.typing import AnnotationT, BoolArray, FloatArray, NumericArray
@@ -218,7 +218,9 @@ def create_layered_volume(
         ignore_names = [
             region_map.get(child, attr="acronym")
             for child in ignore_ids_
-            if re.match(metadata_ignore["query"], region_map.get(child, attr="acronym"))
+            if re.match(
+                metadata_ignore["query"], region_map.get(child, attr=metadata_ignore["attribute"])
+            )
         ]
         ignore_ids = [region_map.find(child, attr="acronym").pop() for child in ignore_names]
 

--- a/atlas_commons/utils.py
+++ b/atlas_commons/utils.py
@@ -208,16 +208,17 @@ def create_layered_volume(
     assert_metadata_content(metadata)
 
     if "ignore" in metadata:
+        metadata_ignore = metadata["ignore"]
         ignore_ids_ = region_map.find(
-            metadata["ignore"]["name"],
-            attr=metadata["ignore"]["attribute"],
+            metadata_ignore["name"],
+            attr=metadata_ignore["attribute"],
             with_descendants=metadata["region"].get("with_descendants", False),
         )
 
         ignore_names = [
             region_map.get(child, attr="acronym")
             for child in ignore_ids_
-            if re.match(metadata["ignore"]["query"], region_map.get(child, attr="acronym"))
+            if re.match(metadata_ignore["query"], region_map.get(child, attr="acronym"))
         ]
         ignore_ids = [region_map.find(child, attr="acronym").pop() for child in ignore_names]
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,12 @@
 name = atlas_commons
 black_version = 22.0
 
-[tox]
-envlist =
-    check-version
-    lint
-    py38
-    docs
-    tests
-
 [testenv]
 extras = tests
 passenv = PYTHONPATH
-commands = pytest tests
+# avoid DeprecationWarning from nptyping
+# https://github.com/ramonhagenaars/nptyping/issues/102
+commands = pytest -W "ignore::DeprecationWarning:nptyping.typing_" tests
 
 [testenv:lint]
 passenv = PYTHONPATH


### PR DESCRIPTION
Add an ignore case to `create_layered_volume`  based on an optional key in the metadata dictionary to allow literature-based barrel column names with queries present in the pipeline. 

The regex cases  (`"queries": ["@.*1[ab]?$", "@.*[2-3][ab]?$", "@.*4[ab]?$", "@.*5[ab]?$", "@.*6[ab]?$"]` ) struggled with the following pattern:
```
SSp-bfd:
    SSp-bfd-C1
        SSp-bfd-C1-1
        SSp-bfd-C1-2
        SSp-bfd-C1-3
...
```
Where the name of the barrel includes one of the layer numbers at the end (1, 2, 3, 4, 5).  So for example column name ending with number 1, i.e. `SSp-bfd-C1`, would be included in the indices found for layer 1. 

New suggested metadata has to follow this pattern (to be added into `atlas-placement-hints`):
```
{
    "region": {
        "name": "Isocortex",
        "query": "Isocortex",
        "attribute": "acronym",
        "with_descendants": true

    },
    "layers": {
        "names": ["layer_1", "layer_2", "layer_3", "layer_4", "layer_5", "layer_6"],
        "queries": ["@.*1[ab]?$", "@.*2[ab]?$", "@.*[^/]3[ab]?$", "@.*4[ab]?$", "@.*5[ab]?$", "@.*6[ab]?$"],
        "attribute": "acronym",
        "with_descendants": true
    },
    "ignore":{
        "name":"SSp-bfd",
        "query": "SSp-bfd-[^-]*$",
        "attribute": "acronym",
        "with_descendants": true
    }
}
```


Find a more detailed description of the issue in `atlas-placement-hints`: [https://github.com/BlueBrain/atlas-placement-hints/issues/12](issue) with visualizations.


The only alternative implementation I can think of would mimic the behaviour of `assert_leaf_node` and require loading a specific hierarchy dictionary to check if a given node has children.

@lecriste and @mgeplf please let me know what do you think, thanks




